### PR TITLE
Fix Github raw content URL for public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There should be a plenty of examples of this in [our PR section](https://github.
 
 To encrypt your CLA, you need gpg. First, obtain the public key of the Jenkins board:
 
-    curl https://raw.github.com/jenkinsci/infra-cla/approved/publicKey.asc | gpg --import
+    curl https://raw.githubusercontent.com/jenkinsci/infra-cla/approved/publicKey.asc | gpg --import
 
 The command to sign it is:
 


### PR DESCRIPTION
So that the curl command actually works OOTB (as now the page redirects to
the new one, but curl wouldn't follow it without -L).