### PR TITLE
Update maintainer checklist to not add signatories to the Core team by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,3 @@ A board member accepts a submitted PR via the following step.
 * Check that `cla.pdf.asc` can be indeed decrypted, and make sure it has valid content
 * Merge the PR
 * Create a signed tag (`git tag -s`) on the merge commit to create a proof
-* Add the person to [the core team](https://github.com/orgs/jenkinsci/teams/core)


### PR DESCRIPTION
We use ICLA for other purposes now, including access to Twitter/YouTube. No need to add everybody to the core team, because not everyone is going to maintain the core