### PR TITLE
Update the Corporate CLA guidelines to use the Jenkins Board mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The command to sign it is:
 
 
 ## Corporate CLA
-If you work on Jenkins core on behalf of your employer, your company needs to have CCLA in place. Have CCLA printed, signed, scanned back to PDF, then send it to `jenkinsci-cla@googlegroups.com` along with [your account on Jenkins](https://jenkins-ci.org/account).
+If you work on Jenkins core on behalf of your employer, your company needs to have CCLA in place. Have CCLA printed, signed, scanned back to PDF, then send it to `jenkinsci-board@googlegroups.com` along with [your account on Jenkins](https://jenkins-ci.org/account).
 
 # How to accept PR
 A board member accepts a submitted PR via the following step.


### PR DESCRIPTION
At the moment new @jenkinsci/board members do not have access to the jenkinsci-cla@googlegroups.com mailing list. I have requested access a while ago, but the access has not been granted yet.

As discussed with @rtyler in the Infra IRC, I have an alternative suggestion: let's just use the Board mailing list to keep things simple. Corporate CLA has a low traffic, so IMHO having a special mailing list for it is not justified.
