### PR TITLE
Remove trailing blank line from markewaite properties file

### DIFF
--- a/collected/icla/markewaite/committer.properties
+++ b/collected/icla/markewaite/committer.properties
@@ -1,4 +1,3 @@
 name=Mark Waite
 email=mark.waite@cloudbees.com
 github=markewaite
-


### PR DESCRIPTION
## Remove trailing blank line from markewaite properties file

Part of the [Corporate Contributor License Agreement instructions](https://docs.linuxfoundation.org/lfx/easycla/v2-current/contributors/corporate-contributor#github).

Testing that Mark Waite has been correctly added as a Corporate Contributor License Agreement administrator for CloudBees.
